### PR TITLE
Composer: phpUnit as non-dev dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,7 @@ matrix:
   - php: '5.6'
   - env: WP_VERSION=nightly
   - env: PHPUNIT_VERSION=~7 WP_VERSION=4.9
-  - env: PHPUNIT_VERSION="7.1.*" WP_VERSION=4.9
   - env: PHPUNIT_VERSION="7.2.*" WP_VERSION=4.9
-  - env: PHPUNIT_VERSION="7.3.*" WP_VERSION=4.9
   - env: PHPUNIT_VERSION="7.4.*" WP_VERSION=4.9
   - env: PHPUNIT_VERSION="7.5.*" WP_VERSION=4.9
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ matrix:
   - php: '5.6'
   - env: WP_VERSION=nightly
   - env: PHPUNIT_VERSION=~7 WP_VERSION=4.9
+  - env: PHPUNIT_VERSION="7.1.*" WP_VERSION=4.9
+  - env: PHPUNIT_VERSION="7.2.*" WP_VERSION=4.9
+  - env: PHPUNIT_VERSION="7.3.*" WP_VERSION=4.9
+  - env: PHPUNIT_VERSION="7.4.*" WP_VERSION=4.9
+  - env: PHPUNIT_VERSION="7.5.*" WP_VERSION=4.9
   include:
   # additional combination among env (as above)
   - php: '5.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
 
 env:
   global:
-    - PHPUNIT_VERSION=~6
+    - PHPUNIT_VERSION=6.5.*
     - PHPUNIT_MOCK_VERSION=~5
   matrix:
     # see https://codex.wordpress.org/WordPress_Versions
@@ -24,13 +24,20 @@ matrix:
   allow_failures:
   - php: '5.6'
   - env: WP_VERSION=nightly
-  - env: PHPUNIT_VERSION=~7 PHPUNIT_MOCK_VERSION=~6 WP_VERSION=4.9
+  - env: PHPUNIT_VERSION=~7 WP_VERSION=4.9
   include:
   # additional combination among env (as above)
   - php: '5.6'
-    env: PHPUNIT_VERSION=~5 PHPUNIT_MOCK_VERSION=~3 WP_VERSION=4.9
+    env: PHPUNIT_VERSION=~5 WP_VERSION=4.9
   - php: '7.1'
-    env: PHPUNIT_VERSION=~7 PHPUNIT_MOCK_VERSION=~6 WP_VERSION=4.9
+    env: PHPUNIT_VERSION=~7 WP_VERSION=4.9
+  # Introducing intermediate version tests
+  - php: '7.0'
+    env: PHPUNIT_VERSION="7.2.*" WP_VERSION=4.9
+  - php: '7.1'
+    env: PHPUNIT_VERSION="7.4.*" WP_VERSION=4.9
+  - php: '7.2'
+    env: PHPUNIT_VERSION="7.5.*"WP_VERSION=4.9
 
 services:
   - mysql
@@ -38,7 +45,7 @@ services:
 before_install:
   - mysql -e 'CREATE DATABASE dev;'
   # Try supporting other versions
-  - composer require phpunit/phpunit-mock-objects:$PHPUNIT_MOCK_VERSION phpunit/phpunit:$PHPUNIT_VERSION
+  - composer require --update-with-dependencies phpunit/phpunit:$PHPUNIT_VERSION
 
 install:
   - composer update

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
 env:
   global:
     - PHPUNIT_VERSION=6.5.*
-    - PHPUNIT_MOCK_VERSION=~5
   matrix:
     # see https://codex.wordpress.org/WordPress_Versions
     # see https://phpunit.de/supported-versions.html
@@ -37,7 +36,7 @@ matrix:
   - php: '7.1'
     env: PHPUNIT_VERSION="7.4.*" WP_VERSION=4.9
   - php: '7.2'
-    env: PHPUNIT_VERSION="7.5.*"WP_VERSION=4.9
+    env: PHPUNIT_VERSION="7.5.*" WP_VERSION=4.9
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,11 @@ matrix:
   - php: '7.1'
     env: PHPUNIT_VERSION=~7 WP_VERSION=4.9
   # Introducing intermediate version tests
-  - php: '7.0'
+  - php: '7.3'
     env: PHPUNIT_VERSION="7.2.*" WP_VERSION=4.9
-  - php: '7.1'
-    env: PHPUNIT_VERSION="7.4.*" WP_VERSION=4.9
   - php: '7.2'
+    env: PHPUNIT_VERSION="7.4.*" WP_VERSION=4.9
+  - php: '7.1'
     env: PHPUNIT_VERSION="7.5.*" WP_VERSION=4.9
 
 services:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We do not require that much
 ([see Packagist.org for more details](https://packagist.org/packages/pretzlaw/wp-integration-test)):
 
 - PHP 7.0 - 7.3
-- phpUnit 6
+- phpUnit 6.5 - 7.5
 - WordPress 4.9 - 5.0
 
 Tests expand continuously to cover a bigger range one day

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   },
   "require": {
-    "phpunit/phpunit": "~ 6.5 || <= 7.5"
+    "phpunit/phpunit": "~6.5 || <= 7.5"
   },
   "require-dev": {
     "wp-cli/wp-cli": "1.5.*"

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,9 @@
     }
   },
   "require": {
-    "phpunit/phpunit-mock-objects": "~5"
+    "phpunit/phpunit": "~ 6.5 || <= 7.5"
   },
   "require-dev": {
-    "phpunit/phpunit": "~6",
     "wp-cli/wp-cli": "1.5.*"
   }
 }

--- a/lib/Pretzlaw/WPInt/Constraint/PluginIsActive.php
+++ b/lib/Pretzlaw/WPInt/Constraint/PluginIsActive.php
@@ -66,7 +66,7 @@ class PluginIsActive extends Constraint
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return 'is active';
     }

--- a/lib/Pretzlaw/WPInt/Constraint/WpHookEmpty.php
+++ b/lib/Pretzlaw/WPInt/Constraint/WpHookEmpty.php
@@ -30,7 +30,7 @@ abstract class WpHookEmpty extends WpHookExists
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return 'has callbacks registered';
     }

--- a/lib/Pretzlaw/WPInt/Constraint/WpHookExists.php
+++ b/lib/Pretzlaw/WPInt/Constraint/WpHookExists.php
@@ -44,7 +44,7 @@ abstract class WpHookExists extends Constraint
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return 'exists';
     }

--- a/lib/Pretzlaw/WPInt/Constraint/WpHookHasCallback.php
+++ b/lib/Pretzlaw/WPInt/Constraint/WpHookHasCallback.php
@@ -53,7 +53,7 @@ abstract class WpHookHasCallback extends WpHookExists
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return sprintf('does not exist in "%s" filter', $this->filterName);
     }

--- a/lib/Pretzlaw/WPInt/Mocks/Cache.php
+++ b/lib/Pretzlaw/WPInt/Mocks/Cache.php
@@ -139,7 +139,7 @@ class Cache implements MockObject
      *
      * @throws ExpectationFailedException
      */
-    public function __phpunit_verify()
+    public function __phpunit_verify(bool $unsetInvocationMocker = true)
     {
         $this->reset();
 
@@ -167,5 +167,10 @@ class Cache implements MockObject
             // Only reset if we have a history ready.
             $wp_object_cache = static::$originalObjectCache;
         }
+    }
+
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+
     }
 }

--- a/lib/Pretzlaw/WPInt/Mocks/ExpectedFilter.php
+++ b/lib/Pretzlaw/WPInt/Mocks/ExpectedFilter.php
@@ -79,7 +79,7 @@ class ExpectedFilter implements MockObject {
 	 *
 	 * @throws ExpectationFailedException
 	 */
-	public function __phpunit_verify() {
+	public function __phpunit_verify(bool $unsetInvocationMocker = true) {
 		$this->removeFilter();
 
 		try {
@@ -132,7 +132,7 @@ class ExpectedFilter implements MockObject {
 	 */
 	public function __phpunit_getInvocationMocker() {
 		if ( null === $this->invocationMocker ) {
-			$this->invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker( [ $this->name ] );
+			$this->invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker( [ $this->name ], true );
 		}
 
 		return $this->invocationMocker;
@@ -159,4 +159,9 @@ class ExpectedFilter implements MockObject {
     {
         return $this->args;
 	}
+
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+
+    }
 }

--- a/lib/Pretzlaw/WPInt/Mocks/Users/CurrentUserMock.php
+++ b/lib/Pretzlaw/WPInt/Mocks/Users/CurrentUserMock.php
@@ -76,7 +76,7 @@ class CurrentUserMock implements MockObject {
 	 *
 	 * @throws ExpectationFailedException
 	 */
-	public function __phpunit_verify() {
+	public function __phpunit_verify(bool $unsetInvocationMocker = true) {
 		global $current_user;
 
 		$current_user = $this->originalUser;
@@ -92,4 +92,8 @@ class CurrentUserMock implements MockObject {
 	public function __call( $name, $arguments ) {
 
 	}
+
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+    }
 }

--- a/lib/Pretzlaw/WPInt/Tests/Cache/MockCacheTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Cache/MockCacheTest.php
@@ -95,7 +95,8 @@ class MockCacheTest extends TestCase
         wp_cache_set('foo', 1337);
 
         $this->expectException(ExpectationFailedException::class);
-        $this->expectExceptionMessage('Expectation failed for method name is equal to "set" when invoked 1 time(s).');
+        // Quotes change somewhere between phpUnit 7.3 and 7.5
+        $this->expectExceptionMessageRegExp('/Expectation failed for method name is equal to ["\']set["\'] when invoked 1 time\(s\)\./');
 
         $mockCache->__phpunit_verify();
     }

--- a/lib/Pretzlaw/WPInt/Tests/Filter/FilterAssertions/MockFilter/GoneAfterTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Filter/FilterAssertions/MockFilter/GoneAfterTest.php
@@ -4,6 +4,7 @@ namespace Pretzlaw\WPInt\Tests\Filter\FilterAssertions\MockFilter;
 
 
 use Pretzlaw\WPInt\Filter\FilterAssertions;
+use Pretzlaw\WPInt\Mocks\ExpectedFilter;
 use Pretzlaw\WPInt\Tests\AbstractTestCase;
 
 class GoneAfterTest extends AbstractTestCase
@@ -24,11 +25,13 @@ class GoneAfterTest extends AbstractTestCase
 
         static::assertFalse(has_filter(static::$filterName));
 
-        $this->mockFilter(static::$filterName)->expects($this->any());
+        $mock = new ExpectedFilter(static::$filterName);
+        $mock->expects($this->any());
+        $mock->addFilter();
 
         static::assertTrue(has_filter(static::$filterName));
 
-        $this->verifyMockObjects();
+        $mock->__phpunit_verify();
 
         static::assertFalse(has_filter(static::$filterName));
     }


### PR DESCRIPTION
 phpUnit: Require as non-dev with specific versions

Did you know that there are breaking changes from 6.4 to 6.5
and in each minor from 7.3 to 7.5 ?
That's really disgusting and especially time-wasting.

* Adapt to some phpUnit 7 interfaces
* Add further phpUnit 7 versions prior to #5 
* solves #1 