### PR TITLE
filter: Add expected filter on the list of configurable methods

### DIFF
--- a/lib/Pretzlaw/WPInt/Mocks/ExpectedFilter.php
+++ b/lib/Pretzlaw/WPInt/Mocks/ExpectedFilter.php
@@ -132,7 +132,10 @@ class ExpectedFilter implements MockObject {
 	 */
 	public function __phpunit_getInvocationMocker() {
 		if ( null === $this->invocationMocker ) {
-			$this->invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker( [ $this->name ], true );
+			$this->invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker(
+			    [ $this->name, strtolower( $this->name ) ],
+                true
+            );
 		}
 
 		return $this->invocationMocker;


### PR DESCRIPTION
PHPUnit seem to have changed the way it whitelists the things that can be mocked.
This may happened in a patch
and breaks our entire testing.
So we need to adapt to this minor change of the interface.