### PR TITLE
wp: Faster Bootstrap of WP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     }
   },
   "require": {
-    "php": ">= 7.0",
     "phpunit/phpunit": "~6.5 || <= 7.5"
   },
   "require-dev": {

--- a/lib/Pretzlaw/WPInt/ArgumentSwitch.php
+++ b/lib/Pretzlaw/WPInt/ArgumentSwitch.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt;
 
@@ -31,7 +29,7 @@ use PHPUnit\Framework\MockObject\Stub;
 /**
  * Different returns based on arguments
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 class ArgumentSwitch

--- a/lib/Pretzlaw/WPInt/Constraint/MatchesConstraint.php
+++ b/lib/Pretzlaw/WPInt/Constraint/MatchesConstraint.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-09
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Constraint;
 
@@ -30,7 +28,7 @@ use PHPUnit\Framework\Constraint\IsInstanceOf;
 /**
  * ShortcodeHasCallback
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class MatchesConstraint extends Constraint
 {

--- a/lib/Pretzlaw/WPInt/Constraint/PluginIsActive.php
+++ b/lib/Pretzlaw/WPInt/Constraint/PluginIsActive.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 Mike Pretlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-25
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Constraint;
 
@@ -29,7 +27,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 /**
  * Check if plugin is active
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-25
  */
 class PluginIsActive extends Constraint

--- a/lib/Pretzlaw/WPInt/Constraint/Shortcode/AbstractShortcodeConstaint.php
+++ b/lib/Pretzlaw/WPInt/Constraint/Shortcode/AbstractShortcodeConstaint.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-09
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Constraint\Shortcode;
 
@@ -28,7 +26,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 /**
  * AbstractShortcodeConstaint
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 abstract class AbstractShortcodeConstaint extends Constraint
 {

--- a/lib/Pretzlaw/WPInt/Constraint/Shortcode/ShortcodeExists.php
+++ b/lib/Pretzlaw/WPInt/Constraint/Shortcode/ShortcodeExists.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-09
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Constraint\Shortcode;
 
@@ -28,7 +26,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 /**
  * ShortcodeExists
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class ShortcodeExists extends AbstractShortcodeConstaint
 {

--- a/lib/Pretzlaw/WPInt/Constraint/Widget/ContainsWidgetBaseId.php
+++ b/lib/Pretzlaw/WPInt/Constraint/Widget/ContainsWidgetBaseId.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-10
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Constraint\Widget;
 
@@ -28,7 +26,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 /**
  * WidgetExists
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class ContainsWidgetBaseId extends Constraint
 {

--- a/lib/Pretzlaw/WPInt/Constraint/Widget/WidgetIsInstanceOf.php
+++ b/lib/Pretzlaw/WPInt/Constraint/Widget/WidgetIsInstanceOf.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-11
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Constraint\Widget;
 
@@ -28,7 +26,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 /**
  * WidgetUsesClass
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class WidgetIsInstanceOf extends Constraint
 {

--- a/lib/Pretzlaw/WPInt/Mocks/AbstractMockObject.php
+++ b/lib/Pretzlaw/WPInt/Mocks/AbstractMockObject.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-10
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Mocks;
 
@@ -32,7 +30,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * AbstractMockObject
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 abstract class AbstractMockObject implements MockObject
 {

--- a/lib/Pretzlaw/WPInt/Mocks/BackupVariable.php
+++ b/lib/Pretzlaw/WPInt/Mocks/BackupVariable.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-11
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Mocks;
 
@@ -30,7 +28,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * BackupVariable
  *
- * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ * @copyright 2020 M. Pretzlaw (https://rmp-up.de)
  * @method InvocationMocker method($constraint)
  */
 class BackupVariable implements MockObject

--- a/lib/Pretzlaw/WPInt/Mocks/Cache.php
+++ b/lib/Pretzlaw/WPInt/Mocks/Cache.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Mocks;
 
@@ -39,7 +37,7 @@ use Pretzlaw\WPInt\ProxyMocker;
  * This class just fulfills the MockObject interface
  * to remove the mocked cache after each test run.
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  * @method InvocationMocker method($constraint)
  */

--- a/lib/Pretzlaw/WPInt/Mocks/Recovery.php
+++ b/lib/Pretzlaw/WPInt/Mocks/Recovery.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-11
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Mocks;
 
@@ -30,7 +28,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Recovery
  *
- * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ * @copyright 2020 M. Pretzlaw (https://rmp-up.de)
  * @method InvocationMocker method($constraint)
  */
 class Recovery implements MockObject

--- a/lib/Pretzlaw/WPInt/Mocks/Shortcode.php
+++ b/lib/Pretzlaw/WPInt/Mocks/Shortcode.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-10
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Mocks;
 
@@ -35,7 +33,7 @@ use Pretzlaw\WPInt\FilterInvocation;
 /**
  * Shortcode
  *
- * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ * @copyright 2020 M. Pretzlaw (https://rmp-up.de)
  */
 class Shortcode extends AbstractMockObject
 {

--- a/lib/Pretzlaw/WPInt/Mocks/Widget.php
+++ b/lib/Pretzlaw/WPInt/Mocks/Widget.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-11
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Mocks;
 
@@ -29,7 +27,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Widget
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @method InvocationMocker method($constraint)
  */
 class Widget extends AbstractMockObject

--- a/lib/Pretzlaw/WPInt/ProxyInvocationBuilder.php
+++ b/lib/Pretzlaw/WPInt/ProxyInvocationBuilder.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt;
 
@@ -36,7 +34,7 @@ use PHPUnit\Framework\MockObject\Stub\MatcherCollection;
  *
  * This is an intermediate object which helps you building stubs in the invocation matcher.
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 class ProxyInvocationBuilder implements Stub

--- a/lib/Pretzlaw/WPInt/ProxyMocker.php
+++ b/lib/Pretzlaw/WPInt/ProxyMocker.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\MockObject\Stub\MatcherCollection;
  * So we ask each matcher for a return value
  * and suppress the warnings until the end of the test.
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 class ProxyMocker implements MatcherCollection, Invokable

--- a/lib/Pretzlaw/WPInt/Tests/AbstractTestCase.php
+++ b/lib/Pretzlaw/WPInt/Tests/AbstractTestCase.php
@@ -26,7 +26,7 @@ abstract class AbstractTestCase extends TestCase
         $this->traits = new AllTraits();
     }
 
-    protected function assertUnregisterFilterAfterTest(string $filter, ExpectedFilter $mock, string $message = '')
+    protected function assertUnregisterFilterAfterTest(string $filter, ExpectedFilter $mock, string $message = null)
     {
         $hasFilter = new FilterHasCallback($filter);
         $hasNotFilter = new LogicalNot($hasFilter);
@@ -43,7 +43,7 @@ abstract class AbstractTestCase extends TestCase
             // Whatever, we are testing other things here.
         }
 
-        static::assertThat($mock, $hasNotFilter, $message);
+        static::assertThat($mock, $hasNotFilter, (string) $message);
     }
 
     protected function showAllMethods()

--- a/lib/Pretzlaw/WPInt/Tests/Actions/ActionEmptyTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Actions/ActionEmptyTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Actions;
 
@@ -33,7 +31,7 @@ use Pretzlaw\WPInt\Traits\ActionAssertions;
 /**
  * Actions
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 class ActionEmptyTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/Actions/ActionExistsTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Actions/ActionExistsTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Actions;
 
@@ -40,7 +38,7 @@ use Pretzlaw\WPInt\Traits\ActionAssertions;
  *      $this->assertActionNotHasCallback( 'init', 'other_plugin_init' );
  *
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 class ActionExistsTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/Actions/ActionHasCallbackTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Actions/ActionHasCallbackTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Actions;
 
@@ -45,7 +43,7 @@ use Pretzlaw\WPInt\Traits\ActionAssertions;
  *      $this->assertActionNotHasCallback( 'init', 'other_plugin_init' );
  *
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 class ActionHasCallbackTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/Actions/ActionNotEmptyTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Actions/ActionNotEmptyTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Actions;
 
@@ -36,7 +34,7 @@ use Pretzlaw\WPInt\Traits\ActionAssertions;
 /**
  * Actions
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 class ActionNotEmptyTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/Actions/ActionNotHasCallbackTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Actions/ActionNotHasCallbackTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Actions;
 
@@ -35,7 +33,7 @@ use Pretzlaw\WPInt\Traits\ActionAssertions;
 /**
  * Actions
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 class ActionNotHasCallbackTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/AssertionTestCase.php
+++ b/lib/Pretzlaw/WPInt/Tests/AssertionTestCase.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-11
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests;
 
@@ -41,7 +39,7 @@ use PHPUnit\Framework\AssertionFailedError;
  * and "negation" instead of "assertNot" to not spill test things in the
  * auto-complete of the IDE.
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 interface AssertionTestCase
 {

--- a/lib/Pretzlaw/WPInt/Tests/Cache/MockCacheGetTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Cache/MockCacheGetTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Cache;
 
@@ -32,7 +30,7 @@ use Pretzlaw\WPInt\Traits\CacheAssertions;
 /**
  * Cache
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 class MockCacheGetTest extends TestCase

--- a/lib/Pretzlaw/WPInt/Tests/Cache/MockCacheTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Cache/MockCacheTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Cache;
 
@@ -32,7 +30,7 @@ use Pretzlaw\WPInt\Traits\CacheAssertions;
 /**
  * Cache
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 class MockCacheTest extends TestCase

--- a/lib/Pretzlaw/WPInt/Tests/Functions/DisableWpDieTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Functions/DisableWpDieTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 Mike Pretlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-24
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Functions;
 
@@ -33,7 +31,7 @@ use Pretzlaw\WPInt\Traits\FunctionsAssertions;
 /**
  * DisableWpDieTest
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-24
  */
 class DisableWpDieTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/MetaData/ExpectedMetaUpdateTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/MetaData/ExpectedMetaUpdateTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 Mike Pretlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-24
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\MetaData;
 
@@ -34,7 +32,7 @@ use Pretzlaw\WPInt\Traits\MetaDataAssertions;
 /**
  * Assert update_metadata
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-24
  */
 class ExpectedMetaUpdateTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/MetaData/ExpectedMetaUpdateTest/WatchSpecificValuesTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/MetaData/ExpectedMetaUpdateTest/WatchSpecificValuesTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 Mike Pretlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-24
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\MetaData\ExpectedMetaUpdateTest;
 
@@ -47,7 +45,7 @@ use Pretzlaw\WPInt\Traits\MetaDataAssertions;
  * The test succeeds when "foo_enabled" will set to "yes" at some point.
  * But it would fail if there is no such assignment during runtime.
  *
- * @copyright 2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright 2020 M. Pretzlaw (https://rmp-up.de)
  * @since     2018-12-24
  */
 class WatchSpecificValuesTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/MockTestCase.php
+++ b/lib/Pretzlaw/WPInt/Tests/MockTestCase.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-11
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests;
 

--- a/lib/Pretzlaw/WPInt/Tests/Mocks/MockMetaDataTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Mocks/MockMetaDataTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 Mike Pretlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-25
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Mocks;
 
@@ -47,7 +45,7 @@ use Prophecy\Argument\Token\AnyValueToken;
  *           });
  *
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-25
  */
 class MockMetaDataTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/Mocks/Post/ExpectWpInsertPost/InsertingPostTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Mocks/Post/ExpectWpInsertPost/InsertingPostTest.php
@@ -10,18 +10,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 Mike Pretlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-23
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Mocks\Post\ExpectWpInsertPost;
 
@@ -36,7 +34,7 @@ use Pretzlaw\WPInt\Traits\PostAssertions;
 /**
  * InsertingPostTest
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-23
  */
 class InsertingPostTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/Mocks/Post/ExpectWpInsertPostTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Mocks/Post/ExpectWpInsertPostTest.php
@@ -10,18 +10,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 Mike Pretlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-23
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Mocks\Post;
 
@@ -31,7 +29,7 @@ use Pretzlaw\WPInt\Tests\AbstractTestCase;
 /**
  * wp_insert_post
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-23
  */
 class ExpectWpInsertPostTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/Mocks/User/CurrentUserMockTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Mocks/User/CurrentUserMockTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 Mike Pretlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-23
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Mocks\User;
 
@@ -44,7 +42,7 @@ use Pretzlaw\WPInt\Traits\UserAssertions;
  * Now functions like `wp_get_current_user`
  * or `get_current_user_id` will return the mocked data.
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-23
  */
 class CurrentUserMockTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/Plugins/AssertPluginIsActiveTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Plugins/AssertPluginIsActiveTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 Mike Pretlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-25
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Plugins;
 
@@ -43,7 +41,7 @@ use Pretzlaw\WPInt\Traits\PluginAssertions;
  * The second one checks if the plugin has been disabled
  * or fails if it has been enabled.
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-25
  */
 class AssertPluginIsActiveTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/Posts/PostTypeAssertions/AssertPostTypeArgsTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Posts/PostTypeAssertions/AssertPostTypeArgsTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Posts\PostTypeAssertions;
 
@@ -31,7 +29,7 @@ use Pretzlaw\WPInt\Traits\PostTypeAssertions;
 /**
  * Post-Types
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 class AssertPostTypeArgsTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/Posts/PostTypeAssertionsTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Posts/PostTypeAssertionsTest.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Posts;
 
@@ -30,7 +28,7 @@ use Pretzlaw\WPInt\Traits\PostTypeAssertions;
 /**
  * Post-Types
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 class PostTypeAssertionsTest extends AbstractTestCase

--- a/lib/Pretzlaw/WPInt/Tests/Shortcodes/MockShortcodeTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Shortcodes/MockShortcodeTest.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-10
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Shortcodes;
 
@@ -35,7 +33,7 @@ use ReflectionMethod;
 /**
  * MockShortcodeTest
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class MockShortcodeTest extends ShortcodesTestCase
 {

--- a/lib/Pretzlaw/WPInt/Tests/Shortcodes/ShortcodeExistsTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Shortcodes/ShortcodeExistsTest.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-10
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Shortcodes;
 
@@ -31,7 +29,7 @@ use Pretzlaw\WPInt\WPAssert;
 /**
  * Assert that a shortcode exists
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class ShortcodeExistsTest extends ShortcodesTestCase
 {

--- a/lib/Pretzlaw/WPInt/Tests/Shortcodes/ShortcodeHasCallbackTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Shortcodes/ShortcodeHasCallbackTest.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-10
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Shortcodes;
 
@@ -34,7 +32,7 @@ use WP_Widget;
 /**
  * Shortcode has callback
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class ShortcodeHasCallbackTest extends ShortcodesTestCase
 {

--- a/lib/Pretzlaw/WPInt/Tests/ShortcodesTestCase.php
+++ b/lib/Pretzlaw/WPInt/Tests/ShortcodesTestCase.php
@@ -14,19 +14,17 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-10
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests;
 
 /**
  * ShortcodesTestCase
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class ShortcodesTestCase extends AbstractTestCase
 {

--- a/lib/Pretzlaw/WPInt/Tests/Widgets/ExistsTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Widgets/ExistsTest.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-10
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Widgets;
 
@@ -32,7 +30,7 @@ use WP_Widget;
 /**
  * Widget with specific base id is (not) registered
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class ExistsTest extends WidgetsTestCase implements AssertionTestCase
 {

--- a/lib/Pretzlaw/WPInt/Tests/Widgets/IsInstanceOfTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Widgets/IsInstanceOfTest.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-11
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Widgets;
 
@@ -34,7 +32,7 @@ use WP_Widget;
 /**
  * IsInstanceOfTest
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class IsInstanceOfTest extends WidgetsTestCase implements AssertionTestCase
 {

--- a/lib/Pretzlaw/WPInt/Tests/Widgets/MockWidget/UnregisterAllWidgetsTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Widgets/MockWidget/UnregisterAllWidgetsTest.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-11
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Widgets\MockWidget;
 
@@ -29,7 +27,7 @@ use WP_Widget;
 /**
  * UnregisterAllWidgetsTest
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class UnregisterAllWidgetsTest extends WidgetsTestCase
 {

--- a/lib/Pretzlaw/WPInt/Tests/Widgets/MockWidget/UnregisterWidgetsByIdTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Widgets/MockWidget/UnregisterWidgetsByIdTest.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-11
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Widgets\MockWidget;
 
@@ -31,7 +29,7 @@ use WP_Widget;
 /**
  * UnregisterWidgetsById
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class UnregisterWidgetsByIdTest extends WidgetsTestCase implements MockTestCase
 {

--- a/lib/Pretzlaw/WPInt/Tests/Widgets/MockWidgetTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Widgets/MockWidgetTest.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-11
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests\Widgets;
 
@@ -31,7 +29,7 @@ use Pretzlaw\WPInt\WPAssert;
 /**
  * Mocking Widgets
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class MockWidgetTest extends WidgetsTestCase implements MockTestCase
 {

--- a/lib/Pretzlaw/WPInt/Tests/WidgetsTestCase.php
+++ b/lib/Pretzlaw/WPInt/Tests/WidgetsTestCase.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-10
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Tests;
 
@@ -31,7 +29,7 @@ use Traversable;
 /**
  * WidgetTestCase
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class WidgetsTestCase extends AbstractTestCase
 {

--- a/lib/Pretzlaw/WPInt/Traits/ActionAssertions.php
+++ b/lib/Pretzlaw/WPInt/Traits/ActionAssertions.php
@@ -19,9 +19,9 @@ trait ActionAssertions {
         static::assertThat($expectedCallback, new LogicalNot(new ActionHasCallback($action)), $message);
     }
 
-    public static function assertActionNotEmpty($action, string $message = '')
+    public static function assertActionNotEmpty($action, string $message = null)
     {
-        static::assertThat($action, new LogicalNot(new ActionEmpty()), $message);
+        static::assertThat($action, new LogicalNot(new ActionEmpty()), (string) $message);
     }
 
     /**
@@ -30,8 +30,8 @@ trait ActionAssertions {
      * @param string $action The action name to check.
      * @param string $message Message in case of error.
      */
-    public function assertActionEmpty(string $action, string $message = '')
+    public function assertActionEmpty(string $action, string $message = null)
     {
-        static::assertThat($action, new ActionEmpty(), $message);
+        static::assertThat($action, new ActionEmpty(), (string) $message);
     }
 }

--- a/lib/Pretzlaw/WPInt/Traits/CacheAssertions.php
+++ b/lib/Pretzlaw/WPInt/Traits/CacheAssertions.php
@@ -9,18 +9,16 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Traits;
 
@@ -29,7 +27,7 @@ use Pretzlaw\WPInt\Mocks\Cache;
 /**
  * CacheAssertions
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 trait CacheAssertions

--- a/lib/Pretzlaw/WPInt/Traits/ShortcodeAssertions.php
+++ b/lib/Pretzlaw/WPInt/Traits/ShortcodeAssertions.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-09
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Traits;
 

--- a/lib/Pretzlaw/WPInt/Traits/WidgetAssertions.php
+++ b/lib/Pretzlaw/WPInt/Traits/WidgetAssertions.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-10
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Traits;
 
@@ -36,7 +34,7 @@ use WP_Widget_Factory;
 /**
  * WidgetTests
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 trait WidgetAssertions
 {

--- a/lib/Pretzlaw/WPInt/Traits/WordPressTests.php
+++ b/lib/Pretzlaw/WPInt/Traits/WordPressTests.php
@@ -9,25 +9,23 @@
  * and under german copyright law. Consider this file as closed source and/or
  * without the permission to reuse or modify its contents.
  * This license is available through the world-wide-web at the following URI:
- * https://mike-pretzlaw.de/license-generic.txt . If you did not receive a copy
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
  * of the license and are unable to obtain it through the web, please send a
- * note to mail@mike-pretzlaw.de so we can mail you a copy.
+ * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    pretzlaw/wp-integration-test
- * @copyright  2018 Mike Pretzlaw
- * @license    https://mike-pretzlaw.de/license-generic.txt
- * @link       https://project.mike-pretzlaw.de/pretzlaw/wp-integration-test
+ * @copyright  2020 M. Pretzlaw
+ * @license    https://rmp-up.de/license-generic.txt
+ * @link       https://project.rmp-up.de/pretzlaw/wp-integration-test
  * @since      2018-12-27
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt\Traits;
 
 /**
  * Simplify usage by gathering all traits in one alias
  *
- * @copyright  2018 Mike Pretzlaw (https://mike-pretzlaw.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  * @since      2018-12-27
  */
 trait WordPressTests

--- a/lib/Pretzlaw/WPInt/WPAssert.php
+++ b/lib/Pretzlaw/WPInt/WPAssert.php
@@ -14,12 +14,10 @@
  * note to mail@rmp-up.de so we can mail you a copy.
  *
  * @package    wp-integration-test
- * @copyright  2020 Pretzlaw
+ * @copyright  2020 M. Pretzlaw
  * @license    https://rmp-up.de/license-generic.txt
  * @since      2020-01-10
  */
-
-declare(strict_types=1);
 
 namespace Pretzlaw\WPInt;
 
@@ -29,7 +27,7 @@ use Pretzlaw\WPInt\Traits\WordPressTests;
 /**
  * WPAssert
  *
- * @copyright  2020 Pretzlaw (https://rmp-up.de)
+ * @copyright  2020 M. Pretzlaw (https://rmp-up.de)
  */
 class WPAssert extends Assert
 {

--- a/lib/Pretzlaw/WPInt/functions.php
+++ b/lib/Pretzlaw/WPInt/functions.php
@@ -51,6 +51,12 @@ function run_wp( $path = null ) {
  * @throws \Exception
  */
 function locate_wordpress() {
+    $env = getenv( 'WP_DIR' );
+    if ( $env && is_dir( $env ) ) {
+        // Got it from environment:
+        return $env;
+    }
+
 	// Locate downwards.
 	$directory     = new \RecursiveDirectoryIterator( getcwd() );
 	$iterator      = new \RecursiveIteratorIterator(
@@ -59,17 +65,10 @@ function locate_wordpress() {
 		\RecursiveIteratorIterator::CATCH_GET_CHILD
 	);
 	$regex         = new \RegexIterator( $iterator, '/.*\/wp-load\.php$/', \RecursiveRegexIterator::GET_MATCH );
-	$possibleFiles = \iterator_to_array( $regex );
 
-	if ( count( $possibleFiles ) > 1 ) {
-		throw new \Exception( 'Could not determine which wp-load.php should be used.' );
+	foreach ( $regex as $wpLoadPath ) {
+		return dirname( current( $wpLoadPath ) );
 	}
 
-	if ( \count( $possibleFiles ) !== 1 ) {
-		throw new \Exception( 'Could not find wp-load.php automatically.' );
-	}
-
-	$match = current( $possibleFiles );
-
-	return dirname( \current( $match ) );
+	throw new \RuntimeException( 'Could not find wp-load.php automatically.' );
 }


### PR DESCRIPTION
While searching for the WordPress dir all directories will be checked.
This is more than we need
and takes much time in big projects.
Therefor we use the very first match from now on
but allow an environment variable to override the result
in case we get it wrong.