### PR TITLE
post: Mock the current post

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ class FooTest extends \PHPUnit\Framework\TestCase {
         );
         
         // Mock posts or meta-data
-        $this->mockGetPost( 1337, [ 'post_content' => 'foobar' ] );
+        $this->mockPost( 1337, [ 'post_content' => 'foobar' ] );
         $this->mockPostMeta( 'some_key', 'Some value!' ); // For all posts
         $this->mockMetaData( 'my-own-cpt', 'another_key', 'ec', 1337 ); // Just for ID 1337
         
@@ -118,9 +118,10 @@ Or make use of the other helper.
 * ->expectWpPostCreationWithSubset
 * ->mockCache
 * ->mockCacheGet
+* ->mockCurrentPost
 * ->mockCurrentUser
 * ->mockFilter
-* ::mockGetPost
+* ->mockPost
 * ->mockMetaData
 * ->mockPostMeta
 * ->mockShortcode

--- a/lib/Pretzlaw/WPInt/Mocks/AbstractMockObjectStack.php
+++ b/lib/Pretzlaw/WPInt/Mocks/AbstractMockObjectStack.php
@@ -1,0 +1,101 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * AbstractMockStack.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-integration-test
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace Pretzlaw\WPInt\Mocks;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\MockObject\InvocationMocker;
+use PHPUnit\Framework\MockObject\Matcher\Invocation;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * AbstractMockStack
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ * @method \PHPUnit\Framework\MockObject\Builder\InvocationMocker method($constraint)
+ */
+abstract class AbstractMockObjectStack implements MockObject
+{
+    /**
+     * @var MockObject[]
+     */
+    private $stack = [];
+
+    public function __construct(array $stack)
+    {
+        $this->stack = $stack;
+    }
+
+    /**
+     * @return InvocationMocker
+     */
+    public function __phpunit_getInvocationMocker()
+    {
+        if (null === $this->invocationMocker) {
+            $this->invocationMocker = new \PHPUnit\Framework\MockObject\InvocationMocker([], true);
+        }
+
+        return $this->invocationMocker;
+    }
+
+    /**
+     * @var InvocationMocker|null
+     */
+    protected $invocationMocker;
+
+    /**
+     * @return bool
+     */
+    public function __phpunit_hasMatchers()
+    {
+        return false === empty($this->stack);
+    }
+
+    /**
+     * @return InvocationMocker
+     */
+    public function __phpunit_setOriginalObject($originalObject)
+    {
+    }
+
+    public function __phpunit_setReturnValueGeneration(bool $returnValueGeneration)
+    {
+    }
+
+    /**
+     * Verifies that the current expectation is valid. If everything is OK the
+     * code should just return, if not it must throw an exception.
+     *
+     * @throws ExpectationFailedException
+     */
+    public function __phpunit_verify(bool $unsetInvocationMocker = null)
+    {
+        foreach ($this->stack as $mock) {
+            $mock->__phpunit_verify($unsetInvocationMocker);
+        }
+    }
+
+    public function expects(Invocation $matcher)
+    {
+        throw new \RuntimeException('This mock has no ::expects() capabilities');
+    }
+}

--- a/lib/Pretzlaw/WPInt/Mocks/Post/CurrentPost.php
+++ b/lib/Pretzlaw/WPInt/Mocks/Post/CurrentPost.php
@@ -1,0 +1,80 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * CurrentPost.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-integration-test
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace Pretzlaw\WPInt\Mocks\Post;
+
+use PHPUnit\Framework\MockObject\Builder\InvocationMocker;
+use Pretzlaw\WPInt\Mocks\AbstractMockObjectStack;
+use Pretzlaw\WPInt\Mocks\BackupVariable;
+use Pretzlaw\WPInt\Mocks\Php\ArrayMock;
+use Pretzlaw\WPInt\Mocks\Recovery;
+use RuntimeException;
+use WP_Post;
+
+/**
+ * CurrentPost
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ * @method InvocationMocker method($constraint)
+ */
+class CurrentPost extends AbstractMockObjectStack
+{
+    /**
+     * @var WP_Post
+     */
+    private $post;
+
+    /**
+     * Copy of the ID to assure correct clean-up
+     *
+     * @var int
+     */
+    private $id;
+
+    public function __construct(WP_Post $post)
+    {
+        if (empty($post->ID) || false === is_numeric($post->ID)) {
+            throw new RuntimeException('You need to add an ID (integer) when mocking the current post');
+        }
+
+        $this->post = $post;
+
+        parent::__construct([
+            new BackupVariable($GLOBALS['post']),
+            new Recovery(
+                function () {
+                    wp_cache_delete($this->id, 'posts');
+                }
+            )
+        ]);
+    }
+
+    public function register()
+    {
+        $this->id = (int) $this->post->ID; // copy id for proper clean-up
+
+        // @todo Should extend/use mockPost
+        wp_cache_set( $this->id, $this->post, 'posts' );
+
+        $GLOBALS['post'] = $this->post;
+    }
+}

--- a/lib/Pretzlaw/WPInt/Tests/AbstractTestCase.php
+++ b/lib/Pretzlaw/WPInt/Tests/AbstractTestCase.php
@@ -13,6 +13,8 @@ use ReflectionMethod;
 
 abstract class AbstractTestCase extends TestCase
 {
+    use WordPressTests;
+
     /**
      * @var AllTraits
      */

--- a/lib/Pretzlaw/WPInt/Tests/Posts/MockCurrentPostTest.php
+++ b/lib/Pretzlaw/WPInt/Tests/Posts/MockCurrentPostTest.php
@@ -1,0 +1,87 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * MockCurrentPostTest.php
+ *
+ * LICENSE: This source file is created by the company around M. Pretzlaw
+ * located in Germany also known as rmp-up. All its contents are proprietary
+ * and under german copyright law. Consider this file as closed source and/or
+ * without the permission to reuse or modify its contents.
+ * This license is available through the world-wide-web at the following URI:
+ * https://rmp-up.de/license-generic.txt . If you did not receive a copy
+ * of the license and are unable to obtain it through the web, please send a
+ * note to mail@rmp-up.de so we can mail you a copy.
+ *
+ * @package   wp-integration-test
+ * @copyright 2020 Pretzlaw
+ * @license   https://rmp-up.de/license-generic.txt
+ */
+
+declare(strict_types=1);
+
+namespace Pretzlaw\WPInt\Tests\Posts;
+
+use Pretzlaw\WPInt\Mocks\Post\CurrentPost;
+use Pretzlaw\WPInt\Tests\AbstractTestCase;
+use WP_Post;
+
+/**
+ * Mock current post
+ *
+ * To temporary mock the current post for one test you can use the
+ *
+ * @copyright 2020 Pretzlaw (https://rmp-up.de)
+ */
+class MockCurrentPostTest extends AbstractTestCase
+{
+
+    /**
+     * @var array
+     */
+    private $expected;
+
+    protected function assertPostIsMocked()
+    {
+        /** @var \WP_Post $post */
+        $post = get_post();
+
+        static::assertInstanceOf(WP_Post::class, $post);
+        static::assertEquals($this->expected['post_title'], $post->post_title);
+        static::assertEquals($this->expected['post_content'], $post->post_content);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $GLOBALS['post'] = null;
+
+        $this->expected = [
+            'ID' => 44,
+            'post_title' => uniqid('', true),
+            'post_content' => uniqid('', true),
+        ];
+
+        static::assertNull(get_post());
+    }
+
+    public function testMockCurrentPost()
+    {
+        $this->mockCurrentPost($this->expected);
+
+        $this->assertPostIsMocked();
+    }
+
+    public function testMockIsGoneAfterTest()
+    {
+        $mock = new CurrentPost(new \WP_Post((object) $this->expected));
+        $mock->register();
+
+        $this->assertPostIsMocked(); // to check if post is there
+
+        $mock->__phpunit_verify(true); // simulate post-test situation
+
+        static::assertNull(get_post());
+    }
+}

--- a/lib/Pretzlaw/WPInt/Traits/PostAssertions.php
+++ b/lib/Pretzlaw/WPInt/Traits/PostAssertions.php
@@ -5,12 +5,33 @@ namespace Pretzlaw\WPInt\Traits;
 
 
 use Pretzlaw\WPInt\Mocks\ExpectedFilter;
+use Pretzlaw\WPInt\Mocks\Php\ArrayMock;
+use Pretzlaw\WPInt\Mocks\Post\CurrentPost;
 use Pretzlaw\WPInt\Mocks\Post\ExpectWpInsertPost;
+use Pretzlaw\WPInt\Mocks\Recovery;
+use RuntimeException;
+use WP_Post;
 
 trait PostAssertions {
-	use PostQueryAssertions;
-
+    /**
+     * @var array
+     * @deprecated 0.4.0 use properly set-up mocks instead
+     */
 	private $wpPostClutter = [];
+
+    /**
+     * @param array $thePost
+     *
+     * @return WP_Post
+     */
+    private function createWpPostObject($data): WP_Post
+    {
+        if (is_array($data)) {
+            return new \WP_Post((object) $data);
+        }
+
+        return $data;
+    }
 
 	protected function expectWpPostCreationWithSubset( $expectedSubset ) {
         $mockObject = new ExpectWpInsertPost($expectedSubset);
@@ -31,5 +52,52 @@ trait PostAssertions {
                 $clutter->removeFilter();
             }
         }
+    }
+
+    /**
+     * @param WP_Post|array $post
+     */
+    protected function mockCurrentPost($post) {
+        $mock = new CurrentPost($this->createWpPostObject($post));
+
+        $this->registerMockObject($mock);
+        $mock->register();
+    }
+
+    protected function mockPost(int $id, $thePost)
+    {
+        $returnVal = $this->createWpPostObject($thePost);
+
+        if (!$returnVal->ID) {
+            $returnVal->ID = $id;
+        }
+
+        wp_cache_set( $id, $returnVal, 'posts' );
+
+        if (isset($this)) {
+            $this->registerMockObject(new Recovery(
+                static function () use ($id) {
+                    wp_cache_delete($id, 'posts');
+                }
+            ));
+        }
+    }
+
+    /**
+     * @param int $id
+     * @param     $returnVal
+     * @deprecated 0.4.0 Use ::mockPost instead
+     */
+    protected static function mockGetPost(int $id, $returnVal)
+    {
+        if ( \is_array( $returnVal ) ) {
+            $returnVal = new \WP_Post( new \ArrayObject( $returnVal ) );
+        }
+
+        if (!$returnVal->ID) {
+            $returnVal->ID = $id;
+        }
+
+        wp_cache_set( $id, $returnVal, 'posts' );
     }
 }

--- a/lib/Pretzlaw/WPInt/Traits/PostQueryAssertions.php
+++ b/lib/Pretzlaw/WPInt/Traits/PostQueryAssertions.php
@@ -8,6 +8,8 @@ trait PostQueryAssertions {
     /**
      * @param int $id Post-ID.
      * @param \WP_Post|array $returnVal Post object or it's data as array (will be transformed into post object).
+     *
+     * @deprecated 0.4.0 Use PostAssertions::mockGetPost instead
      */
     protected static function mockGetPost(int $id, $returnVal)
     {


### PR DESCRIPTION
The function "get_post" usually returns the current post.
By now we could use ::mockGetPost and change the global $post to a specific ID to
mock the current post.
As this is not very intuitive we help out
with the `->mockCurrentPost` method.